### PR TITLE
[Issue #13] Add Google OAuth

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report a bug
-type: Bug
 body:
   - type: textarea
     id: summary

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Request a new feature
-type: Enhancement
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-internal-task.yml
+++ b/.github/ISSUE_TEMPLATE/3-internal-task.yml
@@ -1,6 +1,5 @@
 name: Internal - Task
 description: Describe a task that needs to be completed
-type: Task
 body:
   - type: textarea
     id: summary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,13 +4,10 @@
 - Time to review: [xx] minutes
 
 ### Changes proposed
-
 > What was added, updated, or removed in this PR.
 
 ### Context for reviewers
-
 > Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.
 
 ### Additional information
-
 > Screenshots, GIF demos, code examples or output to help show the changes working as expected.

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist/
 .astro/
 node_modules/ 
 netlify/
+.github/pull_request_template.md

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,4 +1,5 @@
 import GitHub from "@auth/core/providers/github";
+import Google from "@auth/core/providers/google";
 import { defineConfig } from "auth-astro";
 import { db } from "@/db";
 import * as userService from "@/lib/services/user-service";
@@ -8,6 +9,10 @@ export default defineConfig({
     GitHub({
       clientId: process.env.GITHUB_CLIENT_ID,
       clientSecret: process.env.GITHUB_CLIENT_SECRET,
+    }),
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
     }),
   ],
   callbacks: {

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -149,7 +149,7 @@ const user = session?.user;
 
   document.querySelector("#login")?.addEventListener("click", async () => {
     sessionStorage.removeItem("isLoggedIn");
-    await signIn("github");
+    await signIn("google");
   });
 
   document.querySelector("#logout")?.addEventListener("click", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "astro/tsconfigs/strict",
-  "include": [".astro/types.d.ts", "src/**/*"],
+  "include": [".astro/types.d.ts", "src/**/*", "*.ts"],
   "exclude": ["dist", "node_modules"],
   "compilerOptions": {
     "baseUrl": ".",


### PR DESCRIPTION
### Summary

Configures Google as the primary OAuth provider

- Fixes #13 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Fixes GitHub issue templates by removing `type` property
- Fixes formatting of PR template and adds it to `.prettierignore`
- Configures Google OAuth and sets as default provider

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

1. Checkout PR
2. Run `docker compose up -d` to start databases
3. Run `npm run dev`

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1436" height="794" alt="Screenshot 2025-07-16 at 7 00 19 PM" src="https://github.com/user-attachments/assets/724a13d7-952e-4474-9780-4d0272785fab" />
